### PR TITLE
Resolved LintCode import conflicts

### DIFF
--- a/lib/src/l10n_lint_base.dart
+++ b/lib/src/l10n_lint_base.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' show AnalysisError, ErrorSeverity;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:l10n_lint/src/lint_specifications.dart';


### PR DESCRIPTION
Error found:

> /l10n_lint/lib/src/l10n_lint_base.dart:7:1: Error: 'LintCode' is imported from both 'package:analyzer/src/dart/error/lint_codes.dart' and 'package:custom_lint_core/src/lint_codes.dart'.

Resolution:
Selective imports to avoid conflicts