### PR TITLE
chore: upgraded analyzer dependency to 7.3.0

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -27,7 +27,7 @@ extension AstParser on AstNode {
     return this is VariableDeclaration &&
             ((this as VariableDeclaration)
                     .declaredElement
-                    ?.enclosingElement
+                    ?.enclosingElement3
                     ?.isWidgetClass ??
                 false) ||
         _isWithinWidgetRecursively;
@@ -37,7 +37,7 @@ extension AstParser on AstNode {
     return this is VariableDeclaration &&
         ((this as VariableDeclaration)
                 .declaredElement
-                ?.enclosingElement
+                ?.enclosingElement3
                 ?._recursiveEnclosingElementIsWidget ??
             false);
   }
@@ -50,13 +50,13 @@ extension _DartTypeParser on DartType {
 /// if it is not "Widget", then use recursion to check if supertype is widget
 extension ElementParser on Element {
   bool get _recursiveEnclosingElementIsWidget {
-    if (enclosingElement == null) {
+    if (enclosingElement3 == null) {
       return false;
     }
-    if (enclosingElement!.isWidgetClass) {
+    if (enclosingElement3!.isWidgetClass) {
       return true;
     }
-    return enclosingElement!._recursiveEnclosingElementIsWidget;
+    return enclosingElement3!._recursiveEnclosingElementIsWidget;
   }
 
   bool get _hasBuildMethod =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.4.1
+  analyzer: ^7.3.0
   custom_lint_builder: ^0.7.0
   meta: ^1.11.0
 


### PR DESCRIPTION
Upgraded analyzer to 7.3.0 and replaced deprecated `enclosingElement` with `enclosingElement3` as recommended in analyzer changelog